### PR TITLE
chore: remove autoloading namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,6 @@
         }
     },
     "autoload": {
-        "psr-4": {
-            "Minibase\\": "src/"
-        },
         "files": [
             "src/append.php",
             "src/array_keys_exist.php",


### PR DESCRIPTION
_title_

no sense in autoloading PSR-4 when it is all functions and constants that cannot be autoloaded